### PR TITLE
new Symfony Cache Pool Interceptor

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,9 +264,19 @@ Next you can register this custom interceptor on the cache handler and do your o
 
 ```php
 $cacheHandler = Factory::createCacheHandler($poolManager);
-$cacheHandler->addInterceptor($myCustomInterceptor)
+$cacheHandler->addInterceptor($myCustomInterceptor);
 ```
 
+### Using Symfony Cache
+
+You need to initialize DoctrineCommonCacheableInterceptor and now you are abble to use Annotated Cache with Symfony pool manager.
+
+```php
+$cacheHandler = Factory::createCacheHandler($poolManager);
+
+$myCustomInterceptor = new DoctrineCommonCacheableInterceptor($poolManager, $keyGenerator);
+$cacheHandler->addInterceptor($myCustomInterceptor);
+```
 
 ## About
 

--- a/src/Phpro/AnnotatedCache/Interceptor/CacheableInterceptor.php
+++ b/src/Phpro/AnnotatedCache/Interceptor/CacheableInterceptor.php
@@ -117,7 +117,7 @@ class CacheableInterceptor implements InterceptorInterface
      *
      * @return string
      */
-    private function calculateKey(CacheAnnotationInterface $annotation, InterceptionInterface $interception) : string
+    protected function calculateKey(CacheAnnotationInterface $annotation, InterceptionInterface $interception) : string
     {
         return $this->keyGenerator->generateKey($interception, $annotation);
     }
@@ -142,5 +142,13 @@ class CacheableInterceptor implements InterceptorInterface
         }
 
         return $item;
+    }
+
+    /**
+     * @return PoolManagerInterface
+     */
+    protected function getPoolManager(): PoolManagerInterface
+    {
+        return $this->poolManager;
     }
 }

--- a/src/Phpro/AnnotatedCache/Interceptor/DoctrineCommonCacheableInterceptor.php
+++ b/src/Phpro/AnnotatedCache/Interceptor/DoctrineCommonCacheableInterceptor.php
@@ -1,0 +1,52 @@
+<?php
+declare(strict_types=1);
+
+namespace Phpro\AnnotatedCache\Interceptor;
+
+use Phpro\AnnotatedCache\Annotation\Cacheable;
+use Phpro\AnnotatedCache\Annotation\CacheAnnotationInterface;
+use Phpro\AnnotatedCache\Interception\InterceptionSuffixInterface;
+use Phpro\AnnotatedCache\Interceptor\Result\EmptyResult;
+use Phpro\AnnotatedCache\Interceptor\Result\MissResult;
+use Phpro\AnnotatedCache\Interceptor\Result\ResultInterface;
+
+/**
+ * Class DoctrineCommonCacheableInterceptor
+ *
+ * @package Phpro\AnnotatedCache\Interceptor
+ * @author Insekticid <insekticid@exploit.cz>
+ */
+class DoctrineCommonCacheableInterceptor extends CacheableInterceptor
+{
+    /**
+     * @param Cacheable|CacheAnnotationInterface $annotation
+     * @param InterceptionSuffixInterface $interception
+     * @return ResultInterface
+     */
+    public function interceptSuffix(
+        CacheAnnotationInterface $annotation,
+        InterceptionSuffixInterface $interception
+    ) : ResultInterface {
+        if (!$interception->getReturnValue()) {
+            return new EmptyResult();
+        }
+
+        $key = $this->calculateKey($annotation, $interception);
+
+        foreach ($annotation->pools as $poolName) {
+            $pool = $this->getPoolManager()->getPool($poolName);
+            /** @var \Symfony\Component\Cache\CacheItem $item */
+            $item = $pool->getItem($key);
+            $item->set($interception->getReturnValue());
+            $item->tag($annotation->tags);
+
+            if ($annotation->ttl > 0) {
+                $item->expiresAfter($annotation->ttl);
+            }
+
+            $pool->save($item);
+        }
+        
+        return new MissResult($interception, $key, $annotation->pools);
+    }
+}


### PR DESCRIPTION
```yml
annotated_cache:
    key_generator: phpro.annotated_cache.keygenerator.expressions
    pools:
        soap:
            service: cache.adapter.redis

snc_redis:
    clients:
        cache:
            type: predis
            dsn: redis://redis/2
            options:
                connection_timeout: 10
                read_write_timeout: 30

services:
    cache.adapter.redis:
        class: Symfony\Component\Cache\Adapter\RedisAdapter
        arguments: ['@snc_redis.cache', 'namespace']
        calls:
            - [setLogger, ['@logger']]
        tags:
            - { name: 'monolog.logger', channel: 'cache' }

    phpro.cache.interceptor:
        class: Phpro\AnnotatedCache\Interceptor\DoctrineCommonCacheableInterceptor
        arguments: ['@phpro.annotation_cache.cache.pool_manager', '@phpro.annotated_cache.keygenerator.default']
        tags:
            - { name: 'annotated_cache.interceptor' }

```
Fixes issue #2 

Signed-off-by: insekticid <insekticid@exploit.cz>